### PR TITLE
downgrade sling-mock* to avoid trouble with too high oak version dependencies

### DIFF
--- a/ist/parent/2/pom.xml
+++ b/ist/parent/2/pom.xml
@@ -217,8 +217,8 @@
                 <!-- 2.1.10-1.16.0 has problems because of https://issues.apache.org/jira/browse/SLING-9659 , see
                  private/incubator/tests/slingmocktest/src/test/java/com/composum/test/slingmocktest/SlingNamespaceCheckTest.java
                  -->
-                <!-- <version>2.1.10-1.16.0</version> -->
-                <version>3.1.4-1.40.0</version>
+                <!-- We go rather low here: there is already 3.1.8-1.44.0 but that requires oak 1.44, which is only in later Sling/AEM versions. -->
+                <version>3.0.0-1.16.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -231,12 +231,11 @@
 
             <!-- https://mvnrepository.com/artifact/org.apache.sling/org.apache.sling.testing.sling-mock.junit4 -->
             <!-- replaces org.apache.sling.testing.sling-mock -->
-            <!-- This triggers https://issues.apache.org/jira/browse/SLING-8576 which needs a workaround. This workaround
-             should be removed from the POMs once this is updated. -->
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-                <version>3.4.2</version>
+                <!-- Similarily to org.apache.sling.testing.sling-mock-oak we go low here, to avoid needing a too high oak version -->
+                <version>3.1.2</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -251,7 +250,8 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
-                <version>3.4.2</version>
+                <!-- Similarily to org.apache.sling.testing.sling-mock-oak we go low here, to avoid needing a too high oak version -->
+                <version>3.1.2</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
We'd like to be rather backwards compatible, and there isn't any need to go high in the version of sling-mock* - the last versions require rather high oak versions. 